### PR TITLE
Add support for showing `stdout` logs on EMR on EC2

### DIFF
--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -1,5 +1,7 @@
 name: Spark Job Unit Tests
 on: [push]
+env:
+  AWS_DEFAULT_REGION: us-east-1
 jobs:
   pytest:
     strategy:

--- a/src/emr_cli/deployments/emr_ec2.py
+++ b/src/emr_cli/deployments/emr_ec2.py
@@ -1,11 +1,14 @@
+import gzip
 import sys
+from os.path import join
 from typing import List, Optional
 
 import boto3
 from botocore.exceptions import ClientError, WaiterError
-
 from emr_cli.deployments.emr_serverless import DeploymentPackage
-from emr_cli.utils import console_log
+from emr_cli.utils import console_log, parse_bucket_uri
+
+LOG_WAITER_DELAY_SEC = 30
 
 
 class EMREC2:
@@ -15,15 +18,38 @@ class EMREC2:
         self.cluster_id = cluster_id
         self.dp = deployment_package
         self.client = boto3.client("emr")
+        self.s3_client = boto3.client("s3")
 
     def run_job(
-        self, job_name: str, job_args: Optional[List[str]] = None, wait: bool = True
+        self,
+        job_name: str,
+        job_args: Optional[List[str]] = None,
+        wait: bool = True,
+        show_logs: bool = False,
     ):
         """
         Run a Spark job on EMR on EC2. Some important notes:
         1. --deploy-mode cluster is important for distributing dependencies
         2. entrypoint script must be the last argument
+        3. show_logs implies `wait=True`
         """
+        deploy_mode = "client" if show_logs else "cluster"
+        spark_submit_params = self.dp.spark_submit_parameters().params_for("emr_ec2")
+
+        # show_logs is only compatible with client mode
+        # --conf spark.archives is only compatible with cluster mode
+        # So if we have both, we have to throw an error
+        # See https://issues.apache.org/jira/browse/SPARK-36088
+        if (
+            "--conf spark.archives" in spark_submit_params
+            or "--archives" in spark_submit_params
+        ):
+            raise RuntimeError(
+                "--show-stdout is not compatible with projects that make use of "
+                + "--archives.\nPlease 👍 this GitHub issue to voice your support: "
+                + "https://github.com/awslabs/amazon-emr-cli/issues/12"
+            )
+
         try:
             response = self.client.add_job_flow_steps(
                 JobFlowId=self.cluster_id,
@@ -36,11 +62,9 @@ class EMREC2:
                             "Args": [
                                 "spark-submit",
                                 "--deploy-mode",
-                                "cluster",
+                                deploy_mode,
                             ]
-                            + self.dp.spark_submit_parameters()
-                            .params_for("emr_ec2")
-                            .split(" ")
+                            + spark_submit_params.split(" ")
                             + [self.dp.entrypoint_uri()],
                         },
                     }
@@ -52,24 +76,76 @@ class EMREC2:
 
         step_id = response.get("StepIds")[0]
         console_log(f"Job submitted to EMR on EC2 (Step ID: {step_id})")
-        if not wait:
+        if not wait and not show_logs:
             return step_id
 
         console_log("Waiting for step to complete...")
         waiter = self.client.get_waiter("step_complete")
+        job_failed = False
         try:
             waiter.wait(
                 ClusterId=self.cluster_id,
                 StepId=step_id,
             )
+            console_log("Job completed successfully!")
         except WaiterError:
-            console_log("EMR on EC2 step failed, exiting.")
-            sys.exit(1)
+            console_log("EMR on EC2 step failed!")
+            job_failed = True  # So we can exit(1) later
+            if not show_logs:
+                sys.exit(1)
 
-        console_log("Job completed successfully!")
-        # step_response = self.client.describe_step(
-        #     ClusterId=self.cluster_id,
-        #     StepId=step_id,
-        # )
+        if show_logs:
+            # We need to validate s3-logging is enabled and fetch the location of the logs
+            try:
+                logs_location = self._fetch_log_location()
+                stdout_location = self._wait_for_logs(step_id, logs_location, 30 * 60)
+                console_log(f"stdout for {step_id}\n{'-'*36}")
+                self._print_logs(stdout_location)
+                if job_failed:
+                    sys.exit(1)
+            except RuntimeError as e:
+                console_log(f"ERR: {e}")
+                sys.exit(1)
+            except WaiterError as e:
+                console_log(f"ERR: While waiting for logs to appear: {e}")
 
         return step_id
+
+    def _fetch_log_location(self) -> str:
+        """
+        Fetch the cluster and ensure it has the loguri set,
+        then return the s3 location.
+        """
+        cluster_info = self.client.describe_cluster(ClusterId=self.cluster_id)
+        loguri = cluster_info.get("Cluster").get("LogUri")
+        if loguri is None:
+            raise RuntimeError("Cluster does not have S3 logging enabled")
+        return loguri.replace("s3n:", "s3:")
+
+    def _wait_for_logs(self, step_id: str, log_base: str, timeout_secs: int) -> str:
+        """
+        Waits for stdout logs to appear in S3. Checks every LOG_WAITER_DELAY_SEC seconds
+        until `timeout_secs`.
+        """
+        object_name = join(log_base, self.cluster_id, "steps", step_id, "stdout.gz")
+        console_log(f"Waiting for logs to appear in {object_name} ...")
+        bucket_name, key = parse_bucket_uri(object_name)
+        waiter = self.s3_client.get_waiter("object_exists")
+        waiter.wait(
+            Bucket=bucket_name,
+            Key=key,
+            WaiterConfig={
+                "Delay": LOG_WAITER_DELAY_SEC,
+                "MaxAttempts": timeout_secs / LOG_WAITER_DELAY_SEC,
+            },
+        )
+        return object_name
+
+    def _print_logs(self, s3_uri: str):
+        """
+        Downloads and decompresses a gzip file from S3 and prints the logs to stdout.
+        """
+        bucket, key = parse_bucket_uri(s3_uri)
+        gz = self.s3_client.get_object(Bucket=bucket, Key=key)
+        with gzip.open(gz["Body"]) as data:
+            print(data.read().decode())

--- a/src/emr_cli/deployments/emr_serverless.py
+++ b/src/emr_cli/deployments/emr_serverless.py
@@ -223,7 +223,15 @@ class EMRServerless:
         job_args: Optional[List[str]] = None,
         spark_submit_opts: Optional[str] = None,
         wait: bool = True,
+        show_logs: bool = False,
     ):
+        if show_logs:
+            raise RuntimeError(
+                "--show-stdout is not compatible with EMR Serverless (yet).\n"
+                + "Please 👍 this GitHub issue to voice your support: "
+                + "https://github.com/awslabs/amazon-emr-cli/issues/11"
+            )
+
         jobDriver = {
             "sparkSubmit": {
                 "entryPoint": self.dp.entrypoint_uri(),

--- a/src/emr_cli/emr_cli.py
+++ b/src/emr_cli/emr_cli.py
@@ -153,7 +153,7 @@ def deploy(project, entry_point, s3_code_uri):
 )
 @click.option("--job-role", help="IAM Role ARN to use for the job execution")
 @click.option("--wait", default=False, is_flag=True, help="Wait for job to finish")
-@click.option("--s3-code-uri", help="Where to copy code artifacts to")
+@click.option("--s3-code-uri", help="Where to copy/run code artifacts to/from")
 @click.option("--job-name", help="The name of the job", default="emr-cli job")
 @click.option(
     "--job-args",
@@ -167,7 +167,7 @@ def deploy(project, entry_point, s3_code_uri):
 )
 @click.option(
     "--build",
-    help="Do not package and deploy the job assets",
+    help="Package and deploy job artifacts",
     default=False,
     is_flag=True,
 )

--- a/src/emr_cli/emr_cli.py
+++ b/src/emr_cli/emr_cli.py
@@ -1,3 +1,4 @@
+from sys import is_finalizing
 import click
 from emr_cli.config import ConfigReader, ConfigWriter
 from emr_cli.deployments.emr_ec2 import EMREC2
@@ -171,6 +172,12 @@ def deploy(project, entry_point, s3_code_uri):
     default=False,
     is_flag=True,
 )
+@click.option(
+    "--show-stdout",
+    help="Show the stdout of the job after it's finished",
+    default=False,
+    is_flag=True,
+)
 @click.pass_obj
 def run(
     project,
@@ -184,6 +191,7 @@ def run(
     job_args,
     spark_submit_opts,
     build,
+    show_stdout,
 ):
     """
     Run a project on EMR, optionally build and deploy
@@ -216,14 +224,14 @@ def run(
         if job_args:
             job_args = job_args.split(",")
         emrs = EMRServerless(application_id, job_role, p)
-        emrs.run_job(job_name, job_args, spark_submit_opts, wait)
+        emrs.run_job(job_name, job_args, spark_submit_opts, wait, show_stdout)
 
     # cluster_id indicates EMR on EC2 job
     if cluster_id is not None:
         if job_args:
             job_args = job_args.split(",")
         emr = EMREC2(cluster_id, p)
-        emr.run_job(job_name, job_args, wait)
+        emr.run_job(job_name, job_args, wait, show_stdout)
 
 
 cli.add_command(package)

--- a/tests/deployments/test_emr_ec2.py
+++ b/tests/deployments/test_emr_ec2.py
@@ -1,0 +1,39 @@
+import unittest
+from unittest.mock import MagicMock
+
+from emr_cli.deployments.emr_ec2 import EMREC2
+from emr_cli.deployments.emr_serverless import DeploymentPackage
+
+CLUSTER_ID = "j-11111111"
+
+
+class TestEMREC2(unittest.TestCase):
+    def setUp(self):
+        self.obj = EMREC2(CLUSTER_ID, DeploymentPackage())
+
+    def test_fetch_log_location_success(self):
+        self.obj.client.describe_cluster = MagicMock(
+            return_value={"Cluster": {"LogUri": "s3n://example-bucket/logs/"}}
+        )
+        self.assertEqual(self.obj._fetch_log_location(), "s3://example-bucket/logs/")
+
+    def test_fetch_log_location_no_loguri(self):
+        self.obj.client.describe_cluster = MagicMock(return_value={"Cluster": {}})
+        # Ensure that a RuntimeError is raised
+        with self.assertRaises(RuntimeError):
+            self.obj._fetch_log_location()
+
+    def test_fetch_log_location_loguri_none(self):
+        self.obj.client.describe_cluster = MagicMock(
+            return_value={"Cluster": {"LogUri": None}}
+        )
+        # Ensure that a RuntimeError is raised
+        with self.assertRaises(RuntimeError):
+            self.obj._fetch_log_location()
+
+    def test_fetch_log_location_replace_s3n_with_s3(self):
+        self.obj.client.describe_cluster = MagicMock(
+            return_value={"Cluster": {"LogUri": "s3n://example-bucket/logs/"}}
+        )
+        # Ensure that "s3n:" is replaced with "s3:" in the returned S3 location
+        self.assertEqual(self.obj._fetch_log_location(), "s3://example-bucket/logs/")


### PR DESCRIPTION
Adds a new flag `--show-stdout` that prints `stdout` logs after a job finishes with support for EMR on EC2 to start.