### PR TITLE
Feature/runtime roles

### DIFF
--- a/src/emr_cli/deployments/emr_ec2.py
+++ b/src/emr_cli/deployments/emr_ec2.py
@@ -12,7 +12,7 @@ LOG_WAITER_DELAY_SEC = 30
 
 class EMREC2:
     def __init__(
-        self, cluster_id: str, job_role: str, deployment_package: DeploymentPackage, region: str = ""
+        self, cluster_id: str, deployment_package: DeploymentPackage, job_role: str = None, region: str = ""
     ) -> None:
         self.cluster_id = cluster_id
         self.dp = deployment_package

--- a/src/emr_cli/emr_cli.py
+++ b/src/emr_cli/emr_cli.py
@@ -231,7 +231,7 @@ def run(
     if cluster_id is not None:
         if job_args:
             job_args = job_args.split(",")
-        emr = EMREC2(cluster_id, job_role, p)
+        emr = EMREC2(cluster_id, p, job_role)
         emr.run_job(job_name, job_args, wait, show_stdout)
 
 

--- a/src/emr_cli/emr_cli.py
+++ b/src/emr_cli/emr_cli.py
@@ -231,7 +231,7 @@ def run(
     if cluster_id is not None:
         if job_args:
             job_args = job_args.split(",")
-        emr = EMREC2(cluster_id, p)
+        emr = EMREC2(cluster_id, job_role, p)
         emr.run_job(job_name, job_args, wait, show_stdout)
 
 


### PR DESCRIPTION
*Issue #, if available:*

#10 

*Description of changes:*

- Adds support for `--job-role` flag for EMR on EC2.


This PR enables the passing of execution roles at runtime for EMR EC2 steps via the `--job-role` parameter in `emr run`. This allows a tighter scoping of permissions for individual steps, which helps avoid blanket permissions being assigned at a cluster-level.

Changes were validated on an EMR EC2 cluster under release label `emr-6.7.0` with support for `Spark` applications for the following cases:
- [x] Executes under the specified `--job-role` for an EMR cluster with runtime roles enabled.
- [x] Throws an error when a run is attempted without passing the `--job-role` parameter on an EMR cluster with runtime roles enabled:
`[emr-cli]: An error occurred (ValidationException) when calling the AddJobFlowSteps operation: Runtime roles are required for this cluster. Please specify the role using the ExecutionRoleArn parameter.`
- [x] Continues to execute under a cluster's default instance profile for an EMR cluster without runtime roles enabled when no `--job-role` is passed.
- [x] Throws an error when a run is attempted with a `--job-role` parameter on an EMR cluster without runtime roles enabled:
`[emr-cli]: An error occurred (ValidationException) when calling the AddJobFlowSteps operation: Runtime roles are not supported on this cluster. Please remove the ExecutionRoleArn parameter and re-run the request.` 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
