### PR TITLE
EMR EC2 bootstrap

### DIFF
--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -25,13 +25,13 @@ jobs:
       uses: actions/cache@v3
       with:
         path: ~/.local
-        key: ${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-poetry-1.3.2-0
+        key: ${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-poetry-1.5.1-0
     - 
       name: Install Poetry
       uses: snok/install-poetry@v1
       with:
-        # We need Python 3.7 support and 1.6.1 dropped it.
-        version: 1.6.0
+        # Something changed in 1.6.0, but unsure what so pin to 1.5.1
+        version: 1.5.1
         virtualenvs-create: true
         virtualenvs-in-project: true
         installer-parallel: true

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -30,6 +30,8 @@ jobs:
       name: Install Poetry
       uses: snok/install-poetry@v1
       with:
+        # We need Python 3.7 support and 1.6.1 dropped it.
+        version: 1.6.0
         virtualenvs-create: true
         virtualenvs-in-project: true
         installer-parallel: true

--- a/src/emr_cli/deployments/emr_ec2.py
+++ b/src/emr_cli/deployments/emr_ec2.py
@@ -448,4 +448,3 @@ class EMREC2:
             },
         )
         return object_name
-        return object_name

--- a/src/emr_cli/deployments/emr_ec2.py
+++ b/src/emr_cli/deployments/emr_ec2.py
@@ -1,18 +1,270 @@
+import json
 import sys
 from os.path import join
 from typing import List, Optional
 
 import boto3
 from botocore.exceptions import ClientError, WaiterError
+
 from emr_cli.deployments.emr_serverless import DeploymentPackage
 from emr_cli.utils import console_log, parse_bucket_uri, print_s3_gz
 
 LOG_WAITER_DELAY_SEC = 30
 
 
+class Bootstrap:
+    DEFAULT_S3_POLICY_NAME = "emr-cli-S3Access"
+    DEFAULT_GLUE_POLICY_NAME = "emr-cli-GlueAccess"
+
+    def __init__(self, code_bucket: str, log_bucket: str, instance_role_name: str, job_role_name: str):
+        self.code_bucket = code_bucket
+        self.log_bucket = log_bucket or code_bucket
+        self.instance_role_name = instance_role_name
+        self.job_role_name = job_role_name
+        self.s3_client = boto3.client("s3")
+        self.iam_client = boto3.client("iam")
+        self.emr_client = boto3.client("emr")
+
+    def create_environment(self):
+        self._create_s3_buckets()
+        service_role_arn = self._create_service_role()
+        job_role_arn = self._create_runtime_role(service_role_arn)
+
+        # Allow the EC2 instance profile to assume the job role
+        self.iam_client.put_role_policy(
+            RoleName=service_role_arn,
+            PolicyName="AssumeRuntimeRole",
+            PolicyArn=self._runtime_role_policy(),
+        )
+
+        security_config = self._create_security_config()
+        cluster_id = self._create_cluster(security_config)
+        return {
+            "cluster_id": cluster_id,
+            "job_role_arn": job_role_arn,
+            "code_bucket": self.code_bucket,
+            "log_bucket": self.log_bucket,
+        }
+
+    def print_destroy_commands(self, application_id: str):
+        # fmt: off
+        for bucket in set([self.log_bucket, self.code_bucket]):
+            print(f"# aws s3 rm s3://{bucket} --force")
+        for policy in self.iam_client.list_attached_role_policies(RoleName=self.job_role_name).get('AttachedPolicies'):  # noqa E501
+            arn = policy.get('PolicyArn')
+            print(f"aws iam detach-role-policy --role-name {self.job_role_name} --policy-arn {arn}")  # noqa E501
+            print(f"aws iam delete-policy --policy-arn {arn}")  # noqa E501
+        print(f"aws iam delete-role --role-name {self.job_role_name}")
+        # print(f"aws emr-serverless delete-application --application-id {application_id}")  # noqa E501
+        # fmt: on
+
+    def _create_s3_buckets(self):
+        """
+        Creates both the source and log buckets if they don't already exist.
+        """
+        for bucket_name in set([self.code_bucket, self.log_bucket]):
+            self.s3_client.create_bucket(Bucket=bucket_name)
+            console_log(f"Created S3 bucket: s3://{bucket_name}")
+
+    def _create_service_role(self):
+        """
+        Create an EC2 instance profile and role for use with EMR
+        https://docs.aws.amazon.com/emr/latest/ManagementGuide/emr-iam-role-for-ec2.html
+        """
+        # First create a role that can be assumed by EC2
+        response = self.iam_client.create_role(
+            RoleName=self.instance_role_name,
+            AssumeRolePolicyDocument=json.dumps(
+                {
+                    "Version": "2012-10-17",
+                    "Statement": [
+                        {
+                            "Effect": "Allow",
+                            "Principal": {"Service": "ec2.amazonaws.com"},
+                            "Action": "sts:AssumeRole",
+                        }
+                    ],
+                }
+            ),
+        )
+        role_arn = response.get("Role").get("Arn")
+        console_log(f"Created IAM Role: {role_arn}")
+        return role_arn
+
+    def _create_runtime_role(self, instance_profile_role_arn: str):
+        response = self.iam_client.create_role(
+            RoleName=self.job_role_name,
+            AssumeRolePolicyDocument=json.dumps(
+                {
+                    "Version": "2012-10-17",
+                    "Statement": [
+                        {
+                            "Effect": "Allow",
+                            "Principal": {"AWS": instance_profile_role_arn},
+                            "Action": "sts:AssumeRole",
+                        }
+                    ],
+                }
+            ),
+        )
+        role_arn = response.get("Role").get("Arn")
+        console_log(f"Created IAM Role: {role_arn}")
+
+        self.iam_client.attach_role_policy(
+            RoleName=self.job_role_name, PolicyArn=self._create_s3_policy()
+        )
+        self.iam_client.attach_role_policy(
+            RoleName=self.job_role_name, PolicyArn=self._create_glue_policy()
+        )
+
+        return role_arn
+
+    def _create_s3_policy(self):
+        bucket_arns = [
+            f"arn:aws:s3:::{name}" for name in [self.code_bucket, self.log_bucket]
+        ]
+        policy_doc = {
+            "Version": "2012-10-17",
+            "Statement": [
+                {
+                    "Sid": "AllowListBuckets",
+                    "Effect": "Allow",
+                    "Action": ["s3:ListBucket"],
+                    "Resource": bucket_arns,
+                },
+                {
+                    "Sid": "WriteToCodeAndLogBuckets",
+                    "Effect": "Allow",
+                    "Action": ["s3:GetObject", "s3:PutObject", "s3:DeleteObject"],
+                    "Resource": [f"{arn}/*" for arn in bucket_arns],
+                },
+            ],
+        }
+        response = self.iam_client.create_policy(
+            PolicyName=self.DEFAULT_S3_POLICY_NAME,
+            PolicyDocument=json.dumps(policy_doc),
+        )
+        return response.get("Policy").get("Arn")
+
+    def _create_glue_policy(self):
+        policy_doc = {
+            "Version": "2012-10-17",
+            "Statement": [
+                {
+                    "Sid": "GlueCreateAndReadDataCatalog",
+                    "Effect": "Allow",
+                    "Action": [
+                        "glue:GetDatabase",
+                        "glue:GetDataBases",
+                        "glue:CreateTable",
+                        "glue:GetTable",
+                        "glue:GetTables",
+                        "glue:GetPartition",
+                        "glue:GetPartitions",
+                        "glue:CreatePartition",
+                        "glue:BatchCreatePartition",
+                        "glue:GetUserDefinedFunctions",
+                    ],
+                    "Resource": "*",
+                },
+            ],
+        }
+        response = self.iam_client.create_policy(
+            PolicyName=self.DEFAULT_GLUE_POLICY_NAME,
+            PolicyDocument=json.dumps(policy_doc),
+        )
+        return response.get("Policy").get("Arn")
+
+    def _runtime_role_policy(self, runtime_role_arn: str):
+        return {
+            "Version": "2012-10-17",
+            "Statement": [
+                {
+                    "Sid": "AllowRuntimeRoleUsage",
+                    "Effect": "Allow",
+                    "Action": ["sts:AssumeRole", "sts:TagSession"],
+                    "Resource": [runtime_role_arn],
+                }
+            ],
+        }
+
+    def _create_security_config(self):
+        response = self.emr_client.create_security_configuration(
+            Name="emr-cli-runtime-roles",
+            SecurityConfiguration="""{
+                "AuthorizationConfiguration":{
+                    "IAMConfiguration":{
+                        "EnableApplicationScopedIAMRole":true
+                    }
+                }
+            }""",
+        )
+        return response.get("Name")
+
+    def _create_cluster(self, security_config_name: str):
+        """
+        Create a simple Spark EMR on EC2 cluster.
+
+        This cluster is only intended for demo purposes only. To customize the
+        cluster or create a clusetr for production, use the AWS CLI or other
+        Infrastructure as Code services like Terraform, CDK, or CloudFormation.
+        """
+        response = self.emr_client.run_job_flow(
+            Name="emr-cli-demo",
+            ReleaseLabel="emr-6.9.0",
+            Applications=["Spark", "Livy", "JupyterEnterpriseGateway"],
+            AutoTerminationPolicy={"IdleTimeout": 14400},
+            SecurityConfiguration=security_config_name,
+            Instances={
+                "InstanceFleets": {
+                    [
+                        {
+                            "Name": "Primary",
+                            "InstanceFleetType": "MASTER",
+                            "TargetOnDemandCapacity": 1,
+                            "TargetSpotCapacity": 0,
+                            "InstanceTypeConfigs": [
+                                {"InstanceType": "r5.2xlarge"},
+                                {"InstanceType": "r5b.2xlarge"},
+                                {"InstanceType": "r5d.2xlarge"},
+                                {"InstanceType": "r5a.2xlarge"},
+                            ],
+                        },
+                        {
+                            "Name": "Core",
+                            "InstanceFleetType": "CORE",
+                            "TargetOnDemandCapacity": 0,
+                            "TargetSpotCapacity": 1,
+                            "InstanceTypeConfigs": [
+                                {"InstanceType": "c5a.2xlarge"},
+                                {"InstanceType": "m5a.2xlarge"},
+                                {"InstanceType": "r5a.2xlarge"},
+                            ],
+                            "LaunchSpecifications": {
+                                "OnDemandSpecification": {
+                                    "AllocationStrategy": "lowest-price"
+                                },
+                                "SpotSpecification": {
+                                    "TimeoutDurationMinutes": 10,
+                                    "TimeoutAction": "SWITCH_TO_ON_DEMAND",
+                                    "AllocationStrategy": "capacity-optimized",
+                                },
+                            },
+                        },
+                    ]
+                }
+            },
+        )
+        return response.get("JobFlowId")
+
+
 class EMREC2:
     def __init__(
-        self, cluster_id: str, deployment_package: DeploymentPackage, job_role: str = None, region: str = ""
+        self,
+        cluster_id: str,
+        deployment_package: DeploymentPackage,
+        job_role: str = None,
+        region: str = "",
     ) -> None:
         self.cluster_id = cluster_id
         self.dp = deployment_package
@@ -147,4 +399,5 @@ class EMREC2:
                 "MaxAttempts": timeout_secs / LOG_WAITER_DELAY_SEC,
             },
         )
+        return object_name
         return object_name

--- a/src/emr_cli/deployments/emr_ec2.py
+++ b/src/emr_cli/deployments/emr_ec2.py
@@ -12,7 +12,7 @@ LOG_WAITER_DELAY_SEC = 30
 
 class EMREC2:
     def __init__(
-        self, cluster_id: str, deployment_package: DeploymentPackage, job_role: str = None, region: str = ""
+        self, cluster_id: str, job_role: str, deployment_package: DeploymentPackage, region: str = ""
     ) -> None:
         self.cluster_id = cluster_id
         self.dp = deployment_package

--- a/src/emr_cli/deployments/emr_ec2.py
+++ b/src/emr_cli/deployments/emr_ec2.py
@@ -12,7 +12,7 @@ LOG_WAITER_DELAY_SEC = 30
 
 class EMREC2:
     def __init__(
-        self, cluster_id: str, job_role: str, deployment_package: DeploymentPackage, region: str = ""
+        self, cluster_id: str, deployment_package: DeploymentPackage, job_role: str = None, region: str = ""
     ) -> None:
         self.cluster_id = cluster_id
         self.dp = deployment_package

--- a/src/emr_cli/deployments/emr_serverless.py
+++ b/src/emr_cli/deployments/emr_serverless.py
@@ -91,7 +91,9 @@ class Bootstrap:
         Creates both the source and log buckets if they don't already exist.
         """
         for bucket_name in set([self.code_bucket, self.log_bucket]):
-            self.s3_client.create_bucket(Bucket=bucket_name)
+            self.s3_client.create_bucket(Bucket=bucket_name, CreateBucketConfiguration={
+                'LocationConstraint': self.s3_client.meta.region_name
+            })
             console_log(f"Created S3 bucket: s3://{bucket_name}")
 
     def _create_job_role(self):

--- a/src/emr_cli/emr_cli.py
+++ b/src/emr_cli/emr_cli.py
@@ -231,7 +231,7 @@ def run(
     if cluster_id is not None:
         if job_args:
             job_args = job_args.split(",")
-        emr = EMREC2(cluster_id, p, job_role)
+        emr = EMREC2(cluster_id, job_role, p)
         emr.run_job(job_name, job_args, wait, show_stdout)
 
 

--- a/src/emr_cli/emr_cli.py
+++ b/src/emr_cli/emr_cli.py
@@ -270,6 +270,3 @@ cli.add_command(status)
 
 if __name__ == "__main__":
     cli()
-if __name__ == "__main__":
-    cli()
-    cli()

--- a/src/emr_cli/emr_cli.py
+++ b/src/emr_cli/emr_cli.py
@@ -231,7 +231,7 @@ def run(
     if cluster_id is not None:
         if job_args:
             job_args = job_args.split(",")
-        emr = EMREC2(cluster_id, job_role, p)
+        emr = EMREC2(cluster_id, p, job_role)
         emr.run_job(job_name, job_args, wait, show_stdout)
 
 


### PR DESCRIPTION
(unfiled) Add support for bootstrapping an EMR on EC2 cluster.

This feature is primarily for testing and development and not intended to be used in production.