### PR TITLE
Add support for spark-submit params and job args in EMR on EC2

### DIFF
--- a/src/emr_cli/emr_cli.py
+++ b/src/emr_cli/emr_cli.py
@@ -293,7 +293,7 @@ def run(
         if job_args:
             job_args = job_args.split(",")
         emr = EMREC2(cluster_id, p, job_role)
-        emr.run_job(job_name, job_args, wait, show_stdout)
+        emr.run_job(job_name, job_args, spark_submit_opts, wait, show_stdout)
 
 
 cli.add_command(package)


### PR DESCRIPTION
*Issue #, if available:* Unfiled

*Description of changes:*
`emr run` did not propertly support `--spark-submit-opts` or `--job-args` when submitting to EMR on EC2. This PR adds functionality for both of those, including shell-escaping the job args.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
