### PR TITLE
Added emr-serverless-timeout option to the run command.

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,8 +239,6 @@ emr run --entry-point main.py \
 - Run the same job against an EMR on EC2 cluster
 
 ```bash
-
-```bash
 emr run --entry-point main.py \
     --s3-code-uri s3://<BUCKET>/code/ \
     --s3-logs-uri s3://<BUCKET>/logs/ \

--- a/src/emr_cli/deployments/emr_serverless.py
+++ b/src/emr_cli/deployments/emr_serverless.py
@@ -245,6 +245,7 @@ class EMRServerless:
         wait: bool = True,
         show_logs: bool = False,
         s3_logs_uri: Optional[str] = None,
+        timeout: Optional[int] = None,
     ):
         if show_logs and not s3_logs_uri:
             raise RuntimeError("--show-stdout requires --s3-logs-uri to be set.")
@@ -269,12 +270,16 @@ class EMRServerless:
         if s3_logs_uri:
             config_overrides = {"monitoringConfiguration": {"s3MonitoringConfiguration": {"logUri": s3_logs_uri}}}
 
+        if timeout is None:
+            timeout = 12 * 60  # set to AWS default value (12 hours in minutes)
+
         response = self.client.start_job_run(
             applicationId=self.application_id,
             executionRoleArn=self.job_role,
             name=job_name,
             jobDriver=jobDriver,
             configurationOverrides=config_overrides,
+            executionTimeoutMinutes=timeout,
         )
         job_run_id = response.get("jobRunId")
 


### PR DESCRIPTION
*Issue #, if available:*
#43 

*Description of changes:*
Added --emr-serverless-timeout option to the run command.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
