### PR TITLE
fix(deps): bump pyarrow to 14.0.1 in poetry template

### DIFF
--- a/src/emr_cli/templates/poetry/pyproject.toml
+++ b/src/emr_cli/templates/poetry/pyproject.toml
@@ -9,7 +9,7 @@ packages = [{include = "jobs"}]
 [tool.poetry.dependencies]
 python = "^3.7.10"
 pandas = "1.3.5"
-pyarrow = "8.0.0"
+pyarrow = "14.0.1"
 
 [tool.poetry.group.dev.dependencies]
 pyspark = "3.3.0"


### PR DESCRIPTION
## Summary The poetry project template (`src/emr_cli/templates/poetry/pyproject.toml`) still pinned `pyarrow = "8.0.0"`, which is vulnerable to CVE-2023-47248. The other manifests were updated in PRs #36 and #37, but this template was missed, keeping the Dependabot alert active. This bumps pyarrow to `14.0.1` to match the rest of the repo and fully resolve the alert. ## Changes - `src/emr_cli/templates/poetry/pyproject.toml`: `pyarrow` `8.0.0` → `14.0.1` ## Verification Confirmed all pyarrow references across the repo now point to 14.0.1: - `requirements.txt` → `pyarrow==14.0.1` - `src/emr_cli/templates/pyspark/pyproject.toml` → `pyarrow==14.0.1` - `src/emr_cli/templates/poetry/pyproject.toml` → `pyarrow = "14.0.1"`